### PR TITLE
Support return statements without expressions

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -48,7 +48,7 @@ smallStatement {
   PassStatement { kw<"pass"> } |
   BreakStatement { kw<"break"> } |
   ContinueStatement { kw<"continue"> } |
-  ReturnStatement { kw<"return"> commaSep<test | "*" expression> } |
+  ReturnStatement { kw<"return"> commaSep<test | "*" expression>? } |
   YieldStatement { yield } |
   PrintStatement { printKeyword test } |
   RaiseStatement { kw<"raise"> (test (kw<"from"> test | ("," test ("," test)?))?)? } |

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -21,6 +21,17 @@ def foo(a, b): return a + b
 Script(FunctionDefinition(def,VariableName,ParamList(VariableName, VariableName),
   Body(ReturnStatement(return, BinaryExpression(VariableName, ArithOp, VariableName)))))
 
+# Return with no body
+
+def foo(a, b):
+  a = b
+  return
+
+==>
+
+Script(FunctionDefinition(def,VariableName,ParamList(VariableName, VariableName),
+  Body(AssignStatement(VariableName, AssignOp, VariableName), ReturnStatement(return))))
+
 # Conditional
 
 if a: b()
@@ -233,7 +244,7 @@ if None:
   one
 
   two
-     
+
   four
 # comment
   five


### PR DESCRIPTION
Currently the python grammar doesn't support/properly recognize a return statement with no return value.

Example:
```python
foo(a, b):
  return # This is not correctly handled
```
The above is currently unsupported with the current grammar in lever-python.

Reference to cpython grammar:
https://github.com/python/cpython/blob/c347cbe694743cee120457aa6626712f7799a932/Grammar/python.gram#L198
(more readable format on the [official python docs](https://docs.python.org/3/reference/grammar.html), search for `return_stmt`)