### PR TITLE
Fix trailing comma and exponent associativity

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -65,7 +65,7 @@ ImportStatement {
 }
 importedNames { commaSep<VariableName | VariableName kw<"as"> VariableName> }
 
-commaSep<expr> { expr ("," expr?)* }
+commaSep<expr> { expr ("," expr)* ","? }
 
 compoundStatement[@export] {
   IfStatement |

--- a/src/python.grammar
+++ b/src/python.grammar
@@ -1,7 +1,7 @@
 @precedence {
   cond,
   trail,
-  power @left,
+  power @right,
   prefix,
   times @left,
   plus @left,

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -188,3 +188,12 @@ x = 5 if True else 1 if False else 0
 
 Script(AssignStatement(VariableName, AssignOp, ConditionalExpression(Number, if, Boolean, else,
   ConditionalExpression(Number, if, Boolean, else, Number))))
+
+# Exponent is R-to-L associative
+
+2 ** 3 ** 2
+
+==>
+Script(ExpressionStatement(BinaryExpression(
+  Number,ArithOp("**"),
+  BinaryExpression(Number,ArithOp("**"),Number))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -163,12 +163,22 @@ Script(ExpressionStatement(AwaitExpression(await, CallExpression(VariableName, A
 x = [
   1, 2,
   # And
-  3, 4
+  3, 4,
 ]
 
 ==>
 
 Script(AssignStatement(VariableName, AssignOp, ArrayExpression(Number, Number, Comment, Number, Number)))
+
+# Too many commas in brackets
+
+x = [
+  1, 2,,
+]
+
+==>
+
+Script(AssignStatement(VariableName, AssignOp, ArrayExpression(Number, Number, ⚠)))
 
 # Conditional expression
 


### PR DESCRIPTION
Quick fix to two bugs:
- `commaSep` was allowing any number of trailing commas to appear (this is an error in python)
- `**` is right associative

```python
# Too many trailing commas (previously accepted)
x = [1, 2,,]

# Shows the right-left associativity of **
# Output: 512, Since 2**(3**2) = 2**9
print(2 ** 3 ** 2)
```