### PR TITLE
`self` should be VariableName, not keyword

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -29,7 +29,7 @@ FunctionDefinition {
 
 ClassDefinition { kw<"class"> VariableName ArgList? Body }
 
-param { (kw<"self"> | VariableName) TypeDef? (AssignOp{"="} test)? | "*" VariableName? | "**" VariableName | "/" }
+param { VariableName TypeDef? (AssignOp{"="} test)? | "*" VariableName? | "**" VariableName | "/" }
 
 TypeDef { ":" test }
 
@@ -95,7 +95,7 @@ TryStatement {
 
 Body { ":" (simpleStatement | newline continueBody statement (continueBody statement)* (endBody | eof)) }
 
-lambdaParam { (kw<"self"> | VariableName) (AssignOp{"="} test)? | "*" VariableName? | "**" VariableName }
+lambdaParam { VariableName (AssignOp{"="} test)? | "*" VariableName? | "**" VariableName }
 
 lambdaParams[@name="ParamList"] { (lambdaParam ("," lambdaParam)*)? }
 
@@ -145,7 +145,6 @@ expression[@isGroup=Expression] {
   ContinuedString { (String | FormatString) (String | FormatString)+ } |
   "..." |
   kw<"None"> |
-  kw<"self"> |
   @specialize[@name=Boolean]<identifier, "True" | "False">
 }
 

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -129,9 +129,9 @@ class Bar(Foo): pass
 Script(
   ClassDefinition(class, VariableName, Body(
     AssignStatement(VariableName, AssignOp, Number),
-    FunctionDefinition(def, VariableName, ParamList(self), Body(PassStatement(pass))),
-    FunctionDefinition(def, VariableName, ParamList(self), Body(
-      UpdateStatement(MemberExpression(self, PropertyName), UpdateOp, Number))))),
+    FunctionDefinition(def, VariableName, ParamList(VariableName), Body(PassStatement(pass))),
+    FunctionDefinition(def, VariableName, ParamList(VariableName), Body(
+      UpdateStatement(MemberExpression(VariableName, PropertyName), UpdateOp, Number))))),
   ClassDefinition(class, VariableName, ArgList(VariableName), Body(PassStatement(pass))))
 
 # Scope statements
@@ -310,3 +310,11 @@ else:
 Script(IfStatement(if, VariableName, Body(
   IfStatement(if, VariableName, Body(PassStatement(pass)))),
   else, Body(PassStatement(pass))))
+
+# Self not reserved
+
+self = True
+
+==>
+
+Script(AssignStatement(VariableName,AssignOp,Boolean))


### PR DESCRIPTION
In Python, the variable name `self` is used only by convention and does not actually carry any special meaning. As such, it should be treated as a variable name.

The following program is legal, but would require any program using leze-python to handle `VariableName | self` type.

```python
self = True
```

Current: `Script(AssignStatement(self,AssignOp,Boolean))`
Expected: `Script(AssignStatement(VariableName,AssignOp,Boolean))`

Example of how this currently has to be handled (for all params, lambdas, etc.)
```typescript
switch (cursor.node.type.name) {
  case "VariableName":
  case "self":
    // handle variable
  ...
}
```

On the topic of self in python, here's an oldy-but-goody on python's use of [explicit self](http://neopythonic.blogspot.com/2008/10/why-explicit-self-has-to-stay.html) (and by extension why it's not a reserved word).