### PR TITLE
support python3 print statements as print instead of regular function…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/parser.*
 .tern-*
 /dist
+.vscode/

--- a/src/python.grammar
+++ b/src/python.grammar
@@ -265,7 +265,7 @@ FormatReplacement { "{" (YieldExpression | commaSep<"*"? test>) FormatConversion
 
 @context trackIndent from "./tokens.js"
 
-@external tokens legacyPrint from "./tokens.js" { printKeyword[@name="print"] }
+@external tokens print from "./tokens.js" { printKeyword[@name="print"] }
 
 @external tokens indentation from "./tokens" { indent, dedent }
 

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -84,7 +84,7 @@ export const trackIndent = new ContextTracker({
   hash(context) { return context.hash }
 })
 
-export const legacyPrint = new ExternalTokenizer(input => {
+export const print = new ExternalTokenizer(input => {
   for (let i = 0; i < 5; i++) {
     if (input.next != "print".charCodeAt(i)) return
     input.advance()
@@ -93,7 +93,7 @@ export const legacyPrint = new ExternalTokenizer(input => {
   for (let off = 0;; off++) {
     let next = input.peek(off)
     if (next == space || next == tab) continue
-    if (next != parenOpen && next != dot && next != newline && next != carriageReturn && next != hash)
+    if (next != dot && next != newline && next != carriageReturn && next != hash)
       input.acceptToken(printKeyword)
     return
   }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -40,7 +40,7 @@ print('00300:'
 
 ==>
 
-Script(ExpressionStatement(CallExpression(VariableName, ArgList(ContinuedString(String, String)))))
+Script(PrintStatement(print, ParenthesizedExpression(ContinuedString(String, String))))
 
 
 # Format strings

--- a/test/statement.txt
+++ b/test/statement.txt
@@ -284,7 +284,7 @@ except Exception, foo:
 
 Script(
   PrintStatement(print, String),
-  ExpressionStatement(CallExpression(VariableName, ArgList(MemberExpression(VariableName, PropertyName)))),
+  PrintStatement(print, ParenthesizedExpression(MemberExpression(VariableName, PropertyName))),
   TryStatement(try, Body(RaiseStatement(raise, VariableName, String)),
                except, VariableName, VariableName, Body(PassStatement(pass))))
 


### PR DESCRIPTION
Most modern editors highlight the "python" part of a Python 3 function call like a keyword, not a normal call expression.

This supports both Python3 and Python 2 now, instead of just legacy.