### PR TITLE
Fix import multi module

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -106,10 +106,10 @@ smallStatement {
 expressions { commaSep<"*" expression | test> }
 
 ImportStatement {
-  kw<"import"> dottedName (kw<"as"> VariableName)? |
+  kw<"import"> (importList | importedNames) |
   kw<"from"> (("." | "...")+ dottedName? | dottedName) kw<"import"> ("*" | importList | importedNames)
 }
-importedNames { commaSep<VariableName | VariableName kw<"as"> VariableName> }
+importedNames { commaSep<dottedName | dottedName kw<"as"> VariableName> }
 importList[@export] { "(" importedNames ")" }
 
 commaSep<expr> { expr ("," expr)* ","? }


### PR DESCRIPTION
Python's import is very flexible and can cover the following situations:

import a
import a, b
import a as b
import a as b, c as d
import a.b
import a.b, c.d
import a.b as c
import a.b as c, d as e

from . import a
from . import a as b
from .a import b
from .a import b as c
from a import *
from a import b
from a import b, c
from a import (b, c)
from a import b as c
from a import b as c, d as e
from a.b import *
from a.b import c
from a.b import c as d
from a.b import c as d, e as f